### PR TITLE
Move statsd setup from main rad project

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     rad_core (0.0.1)
       pg
       rails (~> 4.2.0)
+      statsd-ruby
 
 GEM
   remote: https://rubygems.org/
@@ -135,6 +136,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    statsd-ruby (1.2.1)
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)

--- a/lib/rad_core/engine.rb
+++ b/lib/rad_core/engine.rb
@@ -1,3 +1,5 @@
+require 'statsd'
+
 module RadCore
   class Engine < ::Rails::Engine
     initializer :append_migrations do |app|

--- a/lib/rad_core/engine.rb
+++ b/lib/rad_core/engine.rb
@@ -2,6 +2,8 @@ require 'statsd'
 
 module RadCore
   class Engine < ::Rails::Engine
+    config.autoload_paths << root.join('lib')
+
     initializer :append_migrations do |app|
       unless app.root.to_s.match root.to_s
         config.paths['db/migrate'].expanded.each do |expanded_path|

--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -1,0 +1,19 @@
+module Stats
+  def self.increment(*args)
+    client.increment(*args) if key
+  end
+
+  def self.gauge(*args)
+    client.gauge(*args) if key
+  end
+
+  def self.client
+    $statsd ||= Statsd.new('statsd.hostedgraphite.com', 8125).tap do |n|
+      n.namespace = key
+    end
+  end
+
+  def self.key
+    ENV['HOSTEDGRAPHITE_APIKEY']
+  end
+end

--- a/rad_core.gemspec
+++ b/rad_core.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 4.2.0'
 
   s.add_dependency 'pg'
+  s.add_dependency 'statsd-ruby'
 
   s.add_development_dependency 'factory_girl_rails'
   s.add_development_dependency 'faker'


### PR DESCRIPTION
In preparation for some changes that will add reporting to statsd from the models.

Once this is merged, I'll open a second request in the main rad project to remove the ``Stats`` wrapper class from there and bump the rad_core version.

@benlovell 